### PR TITLE
fix: :bug: 마크다운 뒤에 단어가 있는 경우 발생하는 버그 해결

### DIFF
--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -100,5 +100,6 @@ export 'src/inline_syntaxes/soft_line_break_syntax.dart';
 export 'src/inline_syntaxes/strikethrough_syntax.dart';
 export 'src/inline_syntaxes/text_syntax.dart';
 export 'src/line.dart';
+export 'src/patterns.dart';
 
 const version = packageVersion;

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -69,9 +69,9 @@ class InlineParser {
     // character position.
     if (document.hasCustomInlineSyntaxes) {
       // We should be less aggressive in blowing past "words".
-      syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s)'));
+      // syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s)'));
     } else {
-      syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
+      // syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
     }
 
     if (document.withDefaultInlineSyntaxes) {
@@ -191,6 +191,7 @@ class InlineParser {
   ///
   /// This is the same strategy as "process emphasis" routine according to the
   /// CommonMark spec: https://spec.commonmark.org/0.30/#phase-2-inline-structure.
+  /// 설명 - delimiter run 처리
   void _processDelimiterRun(int bottomIndex) {
     var currentIndex = bottomIndex + 1;
     // Track the lowest index where we might find an open delimiter given a

--- a/lib/src/inline_syntaxes/delimiter_syntax.dart
+++ b/lib/src/inline_syntaxes/delimiter_syntax.dart
@@ -310,13 +310,18 @@ class DelimiterRun implements Delimiter {
 
     // If it is a right-flanking delimiter run, see
     // http://spec.commonmark.org/0.30/#right-flanking-delimiter-run.
-    final isRightFlanking = !precededByWhitespace &&
+    bool isRightFlanking = !precededByWhitespace &&
         (!precededByPunctuation ||
             followedByWhitespace ||
             followedByPunctuation);
 
     // Make sure the shorter delimiter takes precedence.
     tags.sort((a, b) => a.indicatorLength.compareTo(b.indicatorLength));
+
+    // isRightFlanking이 적용되어 있지 않으면 공백(\s)이나 특수문자($, 괄호 등)가 앞에 있을때 태그(<>)가 잘 동작하지 않음. 
+    // 특수문자,공백과 태그(<>)가 연결되었을때를 처리하기 위해 항상 isRightFlanking을 true함. 
+    // TODO - tag에 따라 isRightFlanking을 조절할 수 있게하자
+    isRightFlanking = true;
 
     return DelimiterRun._(
       node: node,


### PR DESCRIPTION
<태그>마크다운()</태그>확인 => 동작하지 않음
<태그>마크다운()</태그> 확인 => 정상적으로 동작함 <태그>마크다운()</태그># => 정상적으로 동작함 <태그>마크다운</태그>마크다운 => 정상적으로 동작함

태그가 닫히는 부분 앞에 특수문자 &,(,),$,# 등 이 있으며 이후에 단어가 그대로 이어지는 경우에 발생하는 오류를 해결하였습니다.

또한 태그 앞에 알파벳과 숫자가 있을때 복제되는 오류도 수정하였습니다.

delimiter_syntax.dart에서 오른쪽 Flanking이 항상 적용되게 함.
inline_parser에서 알파벳과 숫자를 한번 더 정규표현식으로 파싱하던 부분 제거