### PR TITLE
Feature/SC-1114 마크다운 박스 문법 버그

### DIFF
--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -88,6 +88,7 @@ export 'src/inline_syntaxes/line_break_syntax.dart';
 export 'src/inline_syntaxes/link_syntax.dart';
 export 'src/inline_syntaxes/non_breaking_space_syntax.dart';
 export 'src/inline_syntaxes/single_tex_syntax.dart';
+export 'src/inline_syntaxes/soft_line_break_syntax.dart';
 export 'src/inline_syntaxes/space_syntax.dart';
 export 'src/inline_syntaxes/strikethrough_syntax.dart';
 export 'src/inline_syntaxes/strong_code_syntax.dart';
@@ -96,9 +97,6 @@ export 'src/inline_syntaxes/sup_syntax.dart';
 export 'src/inline_syntaxes/text_syntax.dart';
 export 'src/inline_syntaxes/than_syntax.dart';
 export 'src/inline_syntaxes/underline_syntax.dart';
-export 'src/inline_syntaxes/soft_line_break_syntax.dart';
-export 'src/inline_syntaxes/strikethrough_syntax.dart';
-export 'src/inline_syntaxes/text_syntax.dart';
 export 'src/line.dart';
 export 'src/patterns.dart';
 

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -125,6 +125,7 @@ class BlockParser {
     // For example the `TableSyntax` might not advance the `_pos` in `parse`
     // method, beause of the header row does not match the delimiter row in the
     // number of cells, which makes a table like structure not be recognized.
+    // 설명 - parse()를 실행하고도 _pos가 변하지 않으면 같은 BlockSyntax을 더이상 파싱하지 않는다.
     BlockSyntax? neverMatch;
 
     while (!isDone) {

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -20,6 +20,7 @@ abstract class BlockSyntax {
 
   Node? parse(BlockParser parser);
 
+  // 줄들을 파싱한다. 블록 파서로
   List<Line?> parseChildLines(BlockParser parser) {
     // Grab all of the lines that form the block element.
     final childLines = <Line?>[];
@@ -35,6 +36,7 @@ abstract class BlockSyntax {
   }
 
   /// Gets whether or not [parser]'s current line should end the previous block.
+  /// 블록의 끝인지 확인한다
   static bool isAtBlockEnd(BlockParser parser) {
     if (parser.isDone) return true;
     return parser.blockSyntaxes

--- a/lib/src/block_syntaxes/fenced_align_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_align_block_syntax.dart
@@ -1,5 +1,4 @@
-import 'package:markdown/markdown.dart';
-import 'package:markdown/src/patterns.dart';
+import '../../markdown.dart';
 
 class FencedAlignBlockSyntax extends BlockSyntax {
   FencedAlignBlockSyntax();

--- a/lib/src/block_syntaxes/fenced_box_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_box_block_syntax.dart
@@ -93,9 +93,9 @@ class FencedBoxBlockSyntax extends BlockSyntax {
       childrenLines.forEach((line) {
         var content = line.content;
         content = content
-              .replaceAll('&nbsp;', ' ')
-              .replaceAll('&ensp;', '  ')
-              .replaceAll('&emsp;', '   ');
+            .replaceAll('&nbsp;', ' ')
+            .replaceAll('&ensp;', '  ')
+            .replaceAll('&emsp;', '   ');
 
         if (vocaStrongCodeLongPattern.hasMatch(content)) {
           content = content.replaceAll('<br>', ' ');
@@ -108,15 +108,14 @@ class FencedBoxBlockSyntax extends BlockSyntax {
         text += '$content\n';
       });
 
-      
       var strongCode = '?';
-      
+
       for (var content in lines) {
         content = content
             .replaceAll('&nbsp;', ' ')
             .replaceAll('&ensp;', '  ')
             .replaceAll('&emsp;', '   ');
-        
+
         var attrKey = '';
         if (content.contains('[') && content.contains(']')) {
           attrKey = 'voca-pronunciation-eng';
@@ -125,21 +124,20 @@ class FencedBoxBlockSyntax extends BlockSyntax {
           content = content.replaceAll('`', '');
         } else if (vocaStrongCodeOnlyPattern.hasMatch(content)) {
           attrKey = 'voca-strong-code';
-          
+
           final code = vocaStrongCodeLongPattern.firstMatch(content)!.group(0)!;
           if (code != strongCode) {
-
-               if (element.attributes['voca-lang-kor'] != null && content != '') {
-                element.attributes['voca-lang-kor'] = '${element.attributes['voca-lang-kor']!}---|---';
-                
-              }
-              if (element.attributes['voca-lang-eng'] != null && content != '') {
-                element.attributes['voca-lang-eng'] = '${element.attributes['voca-lang-eng']!}---|---'; 
-              }
+            if (element.attributes['voca-lang-kor'] != null && content != '') {
+              element.attributes['voca-lang-kor'] =
+                  '${element.attributes['voca-lang-kor']!}---|---';
+            }
+            if (element.attributes['voca-lang-eng'] != null && content != '') {
+              element.attributes['voca-lang-eng'] =
+                  '${element.attributes['voca-lang-eng']!}---|---';
+            }
           }
 
           strongCode = code;
-
         } else if (vocaKorPattern.hasMatch(content)) {
           attrKey = 'voca-lang-kor';
         } else if (vocaEngPattern.hasMatch(content)) {
@@ -154,18 +152,17 @@ class FencedBoxBlockSyntax extends BlockSyntax {
 
         if (attrKey != '') {
           element.attributes[attrKey] = content;
-        }        
+        }
       }
 
       if (vocaStrongCodeTextPattern.hasMatch(text)) {
-        final matches =
-            vocaStrongCodeTextPattern.allMatches(text);
-        
+        final matches = vocaStrongCodeTextPattern.allMatches(text);
+
         for (var m in matches) {
           if (m.groupCount > 1) {
             final vocaStrongCode = m.group(1)!;
             final vocaText = m.group(2)!;
-            
+
             // TODO - attribute set하는 코드가 중복임, 따로 뺄것
             if (element.attributes['voca-strong-codes-without-text'] != null &&
                 vocaStrongCode != '') {

--- a/lib/src/block_syntaxes/fenced_box_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_box_block_syntax.dart
@@ -1,5 +1,4 @@
 import 'package:markdown/markdown.dart';
-import 'package:markdown/src/patterns.dart';
 
 class FencedBoxBlockSyntax extends BlockSyntax {
   FencedBoxBlockSyntax();

--- a/lib/src/block_syntaxes/fenced_large_box_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_large_box_block_syntax.dart
@@ -1,5 +1,5 @@
-import 'package:markdown/src/block_syntaxes/fenced_box_block_syntax.dart';
-import 'package:markdown/src/patterns.dart';
+import '../patterns.dart';
+import 'fenced_box_block_syntax.dart';
 
 class FencedLargeBoxBlockSyntax extends FencedBoxBlockSyntax {
   FencedLargeBoxBlockSyntax();

--- a/lib/src/block_syntaxes/fenced_large_tex_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_large_tex_block_syntax.dart
@@ -23,7 +23,7 @@ class FencedLargeTexBlockSyntax extends FencedTexBlockSyntax {
     final childLines = parseChildLines(parser, endBlock);
 
     /// 하나의 문장으로 합침
-    final text = childLines.join('');
+    final text = childLines.join();
 
     /// tex 엘리먼트를 포함한 블록 엘리먼트
     final element = Element.text('texblock', text)

--- a/lib/src/block_syntaxes/fenced_tex_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_tex_block_syntax.dart
@@ -58,7 +58,7 @@ class FencedTexBlockSyntax extends BlockSyntax {
     final childLines = parseChildLines(parser, endBlock);
 
     /// 하나의 문장으로 합침
-    final text = childLines.join('');
+    final text = childLines.join();
 
     /// tex 엘리먼트를 포함한 블록 엘리먼트
     final element = Element.text('texblock', text);

--- a/lib/src/inline_syntaxes/code_syntax.dart
+++ b/lib/src/inline_syntaxes/code_syntax.dart
@@ -65,7 +65,7 @@ class CodeSyntax extends InlineSyntax {
     }
 
     final levelMatch = _levelRegExp.firstMatch(code);
-    
+
     if (levelMatch != null) {
       parser.addNode(
         Element.text(

--- a/lib/src/inline_syntaxes/code_syntax.dart
+++ b/lib/src/inline_syntaxes/code_syntax.dart
@@ -63,17 +63,19 @@ class CodeSyntax extends InlineSyntax {
     if (parser.encodeHtml) {
       code = escapeHtml(code, escapeApos: false);
     }
-    parser.addNode(Element.text('code', code));
 
     final levelMatch = _levelRegExp.firstMatch(code);
-    parser.addNode(
-      Element.text(
-        'code',
-        levelMatch == null
-            ? code
-            : code.replaceAll('O', '●').replaceAll('X', '○'),
-      )..attributes['class'] = levelMatch == null ? '' : 'level',
-    );
+    
+    if (levelMatch != null) {
+      parser.addNode(
+        Element.text(
+          'code',
+          code.replaceAll('O', '●').replaceAll('X', '○'),
+        )..attributes['class'] = 'level',
+      );
+    } else {
+      parser.addNode(Element.text('code', code));
+    }
 
     return true;
   }

--- a/lib/src/inline_syntaxes/delimiter_syntax.dart
+++ b/lib/src/inline_syntaxes/delimiter_syntax.dart
@@ -310,7 +310,7 @@ class DelimiterRun implements Delimiter {
 
     // If it is a right-flanking delimiter run, see
     // http://spec.commonmark.org/0.30/#right-flanking-delimiter-run.
-    bool isRightFlanking = !precededByWhitespace &&
+    var isRightFlanking = !precededByWhitespace &&
         (!precededByPunctuation ||
             followedByWhitespace ||
             followedByPunctuation);

--- a/lib/src/inline_syntaxes/delimiter_syntax.dart
+++ b/lib/src/inline_syntaxes/delimiter_syntax.dart
@@ -318,8 +318,8 @@ class DelimiterRun implements Delimiter {
     // Make sure the shorter delimiter takes precedence.
     tags.sort((a, b) => a.indicatorLength.compareTo(b.indicatorLength));
 
-    // isRightFlanking이 적용되어 있지 않으면 공백(\s)이나 특수문자($, 괄호 등)가 앞에 있을때 태그(<>)가 잘 동작하지 않음. 
-    // 특수문자,공백과 태그(<>)가 연결되었을때를 처리하기 위해 항상 isRightFlanking을 true함. 
+    // isRightFlanking이 적용되어 있지 않으면 공백(\s)이나 특수문자($, 괄호 등)가 앞에 있을때 태그(<>)가 잘 동작하지 않음.
+    // 특수문자,공백과 태그(<>)가 연결되었을때를 처리하기 위해 항상 isRightFlanking을 true함.
     // TODO - tag에 따라 isRightFlanking을 조절할 수 있게하자
     isRightFlanking = true;
 

--- a/lib/src/inline_syntaxes/highlight_syntax.dart
+++ b/lib/src/inline_syntaxes/highlight_syntax.dart
@@ -1,4 +1,4 @@
-import 'package:markdown/markdown.dart';
+import '../../markdown.dart';
 
 class HighlightInlineSyntax extends DelimiterSyntax {
   HighlightInlineSyntax()

--- a/lib/src/inline_syntaxes/inline_html_syntax.dart
+++ b/lib/src/inline_syntaxes/inline_html_syntax.dart
@@ -1,10 +1,9 @@
 // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'package:markdown/src/inline_syntaxes/text_syntax.dart';
-
 import '../charcode.dart';
 import '../patterns.dart';
+import 'text_syntax.dart';
 
 /// Leave inline HTML tags alone, from
 /// [CommonMark 0.30](http://spec.commonmark.org/0.30/#raw-html).

--- a/lib/src/inline_syntaxes/non_breaking_space_syntax.dart
+++ b/lib/src/inline_syntaxes/non_breaking_space_syntax.dart
@@ -1,7 +1,6 @@
-import 'package:markdown/src/inline_parser.dart';
-import 'package:markdown/src/inline_syntaxes/inline_syntax.dart';
-
 import '../ast.dart';
+import '../inline_parser.dart';
+import 'inline_syntax.dart';
 
 class NonBreakingSpace extends InlineSyntax {
   NonBreakingSpace() : super('(&nbsp;|&ensp;|&emsp;)');

--- a/lib/src/inline_syntaxes/space_syntax.dart
+++ b/lib/src/inline_syntaxes/space_syntax.dart
@@ -1,4 +1,4 @@
-import 'package:markdown/markdown.dart';
+import '../../markdown.dart';
 
 class SpaceSyntax extends InlineSyntax {
   SpaceSyntax() : super('( {2,})');

--- a/lib/src/inline_syntaxes/strong_code_syntax.dart
+++ b/lib/src/inline_syntaxes/strong_code_syntax.dart
@@ -1,4 +1,4 @@
-import 'package:markdown/markdown.dart';
+import '../../markdown.dart';
 
 class StrongCodeInlineSyntax extends InlineSyntax {
   StrongCodeInlineSyntax() : super(r'\*\*`(.*?)`\*\*');

--- a/lib/src/inline_syntaxes/sub_syntax.dart
+++ b/lib/src/inline_syntaxes/sub_syntax.dart
@@ -1,4 +1,4 @@
-import 'package:markdown/markdown.dart';
+import '../../markdown.dart';
 
 class SubInlineSyntax extends DelimiterSyntax {
   SubInlineSyntax()

--- a/lib/src/inline_syntaxes/sup_syntax.dart
+++ b/lib/src/inline_syntaxes/sup_syntax.dart
@@ -1,4 +1,4 @@
-import 'package:markdown/markdown.dart';
+import '../../markdown.dart';
 
 class SupInlineSyntax extends DelimiterSyntax {
   SupInlineSyntax()

--- a/lib/src/inline_syntaxes/than_syntax.dart
+++ b/lib/src/inline_syntaxes/than_syntax.dart
@@ -1,6 +1,6 @@
-import 'package:markdown/src/ast.dart';
-import 'package:markdown/src/inline_parser.dart';
-import 'package:markdown/src/inline_syntaxes/inline_syntax.dart';
+import '../ast.dart';
+import '../inline_parser.dart';
+import 'inline_syntax.dart';
 
 class ThanInlineSyntax extends InlineSyntax {
   ThanInlineSyntax() : super('($_lessThan|$_greaterThan)');

--- a/lib/src/inline_syntaxes/underline_syntax.dart
+++ b/lib/src/inline_syntaxes/underline_syntax.dart
@@ -1,4 +1,4 @@
-import 'package:markdown/markdown.dart';
+import '../../markdown.dart';
 
 class UnderlineInlineSyntax extends DelimiterSyntax {
   UnderlineInlineSyntax()

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -174,6 +174,9 @@ final vocaKorPattern = RegExp(r'[ㄱ-ㅎ가-힣]+');
 final vocaEngPattern = RegExp(r'[a-zA-Z]+');
 final vocaEngPronunciationPattern = RegExp(r'\[.*\]+');
 final vocaLevelPattern = RegExp('`(O|X){1,}`');
-final vocaStrongCodeOnlyPattern = RegExp(r'\*\*(n|ad|v|a|\?|[a-zA-Z]){1,5}\*\*');
-final vocaStrongCodeLongPattern = RegExp(r'\*\*(n|ad|v|a|\?|[a-zA-Z]){1,5}\*\*([\w\s].*)');
-final vocaStrongCodeTextPattern = RegExp(r'(\*\*[a-zA-Z]{1,5}\*\*)([\wㄱ-ㅎ가-힣,.$()<>?:\\\+;&~! \n\r]+)');
+final vocaStrongCodeOnlyPattern =
+    RegExp(r'\*\*(n|ad|v|a|\?|[a-zA-Z]){1,5}\*\*');
+final vocaStrongCodeLongPattern =
+    RegExp(r'\*\*(n|ad|v|a|\?|[a-zA-Z]){1,5}\*\*([\w\s].*)');
+final vocaStrongCodeTextPattern =
+    RegExp(r'(\*\*[a-zA-Z]{1,5}\*\*)([\wㄱ-ㅎ가-힣,.$()<>?:\\\+;&~! \n\r]+)');

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -169,9 +169,9 @@ final htmlCharactersPattern = RegExp(
 );
 
 // final vocaKorPattern = RegExp(r'[ㄱ-ㅎ가-힣|\s]+');
-final vocaKorPattern = RegExp(r'[ㄱ-ㅎ가-힣]+');
+final vocaKorPattern = RegExp('[ㄱ-ㅎ가-힣]+');
 // final vocaEngPattern = RegExp(r'[a-zA-Z|\s]+');
-final vocaEngPattern = RegExp(r'[a-zA-Z]+');
+final vocaEngPattern = RegExp('[a-zA-Z]+');
 final vocaEngPronunciationPattern = RegExp(r'\[.*\]+');
 final vocaLevelPattern = RegExp('`(O|X){1,}`');
 final vocaStrongCodeOnlyPattern =

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -34,11 +34,12 @@ final texFencePattern = RegExp(r'^[ ]{0,3}(\$)$');
 /// Fenced blockquotes.
 final blockquoteFencePattern = RegExp(r'^>{3}\s*$');
 
-final largeBoxFencePattern = RegExp(r'^(\:{4,4})(boxed|voca|checked)(.*)$');
+// 박스 문법 처리
+final largeBoxFencePattern = RegExp(r'^(\:{4,})(boxed|voca|checked)(.*)$');
 
-final boxFencePattern = RegExp(r'^(\:{3,3})(boxed|voca|checked)(.*)$');
+final boxFencePattern = RegExp(r'^(\:{3,})(boxed|voca|checked)(.*)$');
 
-final alignFencePattern = RegExp(r'^(\:{3,3})(left|middle|right)(.*)$');
+final alignFencePattern = RegExp(r'^(\:{3,})(left|middle|right)(.*)$');
 
 /// Three or more hyphens, asterisks or underscores by themselves. Note that
 /// a line like `----` is valid as both HR and SETEXT. In case of a tie,
@@ -166,3 +167,13 @@ final htmlCharactersPattern = RegExp(
   '&(?:([a-z0-9]+)|#([0-9]{1,7})|#x([a-f0-9]{1,6}));',
   caseSensitive: false,
 );
+
+// final vocaKorPattern = RegExp(r'[ㄱ-ㅎ가-힣|\s]+');
+final vocaKorPattern = RegExp(r'[ㄱ-ㅎ가-힣]+');
+// final vocaEngPattern = RegExp(r'[a-zA-Z|\s]+');
+final vocaEngPattern = RegExp(r'[a-zA-Z]+');
+final vocaEngPronunciationPattern = RegExp(r'\[.*\]+');
+final vocaLevelPattern = RegExp('`(O|X){1,}`');
+final vocaStrongCodeOnlyPattern = RegExp(r'\*\*(n|ad|v|a|\?|[a-zA-Z]){1,5}\*\*');
+final vocaStrongCodeLongPattern = RegExp(r'\*\*(n|ad|v|a|\?|[a-zA-Z]){1,5}\*\*([\w\s].*)');
+final vocaStrongCodeTextPattern = RegExp(r'(\*\*[a-zA-Z]{1,5}\*\*)([\wㄱ-ㅎ가-힣,.$()<>?:\\\+;&~! \n\r]+)');

--- a/test/block_syntax/fenced_align_block_syntax_test.dart
+++ b/test/block_syntax/fenced_align_block_syntax_test.dart
@@ -25,7 +25,7 @@ void main() {
     test('박스 블락 구문 파싱 테스트', () {
       /// MD 다큐먼트 생성
 
-      final data = ''':::right\n박스 내부\n:::''';
+      const data = ''':::right\n박스 내부\n:::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -39,7 +39,7 @@ void main() {
       /// 블록 엘리먼트 태그, 하위 노드 수 확인
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -63,7 +63,7 @@ void main() {
       /// 첫번째 하위노드 태그 및 텍스트 확인
       expect(
         children?.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',

--- a/test/block_syntax/fenced_align_block_syntax_test.dart
+++ b/test/block_syntax/fenced_align_block_syntax_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:markdown/markdown.dart';
-import 'package:markdown/src/block_syntaxes/fenced_align_block_syntax.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/block_syntax/fenced_box_block_syntax_test.dart
+++ b/test/block_syntax/fenced_box_block_syntax_test.dart
@@ -25,7 +25,7 @@ void main() {
     test('박스 블락 구문 파싱 테스트', () {
       /// MD 다큐먼트 생성
 
-      final data = ''':::boxed\n박스 내부\n:::''';
+      const data = ''':::boxed\n박스 내부\n:::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -39,7 +39,7 @@ void main() {
       /// 블록 엘리먼트 태그, 하위 노드 수 확인
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -58,7 +58,7 @@ void main() {
       /// 첫번째 하위노드 태그 및 텍스트 확인
       expect(
         children?.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -85,7 +85,7 @@ void main() {
     ///       블록의 라벨은 '라벨'이다
     ///       블록의 하위 노드의 내용은 '박스 안' 이다.
     test('박스 블락 구문 파싱 테스트 With 라벨', () {
-      final data = ''':::boxed[라벨]\n박스 안\n:::''';
+      const data = ''':::boxed[라벨]\n박스 안\n:::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -98,7 +98,7 @@ void main() {
 
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having((e) => e.tag, '태그', 'boxedblock')
             .having(
               (e) => e.children,
@@ -130,7 +130,7 @@ void main() {
     test('체크 블락 구문 파싱 테스트', () {
       /// MD 다큐먼트 생성
 
-      final data = ''':::checked\n박스 내부\n:::''';
+      const data = ''':::checked\n박스 내부\n:::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -144,7 +144,7 @@ void main() {
       /// 블록 엘리먼트 태그, 하위 노드 수 확인
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -171,7 +171,7 @@ void main() {
       /// 첫번째 하위노드 태그 및 텍스트 확인
       expect(
         children?.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -199,7 +199,7 @@ void main() {
     ///       블록의 라벨은 '라벨'이다
     ///       블록의 하위 노드의 내용은 '박스 안' 이다.
     test('체크 블락 구문 파싱 테스트 With 라벨', () {
-      final data = ''':::checked[라벨]\n박스 안\n:::''';
+      const data = ''':::checked[라벨]\n박스 안\n:::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -212,7 +212,7 @@ void main() {
 
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having((e) => e.tag, '태그', 'boxedblock')
             .having(
               (e) => e.children,

--- a/test/block_syntax/fenced_large_box_block_syntax_test.dart
+++ b/test/block_syntax/fenced_large_box_block_syntax_test.dart
@@ -26,7 +26,7 @@ void main() {
     test('박스 블락 구문 파싱 테스트', () {
       /// MD 다큐먼트 생성
 
-      final data = '''::::boxed\n박스 내부\n::::''';
+      const data = '''::::boxed\n박스 내부\n::::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -40,7 +40,7 @@ void main() {
       /// 블록 엘리먼트 태그, 하위 노드 수 확인
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -59,7 +59,7 @@ void main() {
       /// 첫번째 하위노드 태그 및 텍스트 확인
       expect(
         children?.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -86,7 +86,7 @@ void main() {
     ///       블록의 하위 노드수는 1개 이다
     ///       블록의 하위 노드의 내용은 '박스 안' 이다.
     test('박스 블락 구문 파싱 테스트 With 라벨', () {
-      final data = '''::::boxed[라벨]\n박스 안\n::::''';
+      const data = '''::::boxed[라벨]\n박스 안\n::::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -99,7 +99,7 @@ void main() {
 
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having((e) => e.tag, '태그', 'boxedblock')
             .having(
               (e) => e.children,
@@ -131,7 +131,7 @@ void main() {
     test('체크 블락 구문 파싱 테스트', () {
       /// MD 다큐먼트 생성
 
-      final data = '''::::checked\n박스 내부\n::::''';
+      const data = '''::::checked\n박스 내부\n::::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -145,7 +145,7 @@ void main() {
       /// 블록 엘리먼트 태그, 하위 노드 수 확인
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -172,7 +172,7 @@ void main() {
       /// 첫번째 하위노드 태그 및 텍스트 확인
       expect(
         children?.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -200,7 +200,7 @@ void main() {
     ///       블록의 라벨은 '라벨'이다
     ///       블록의 하위 노드의 내용은 '박스 안' 이다.
     test('체크 블락 구문 파싱 테스트 With 라벨', () {
-      final data = '''::::checked[라벨]\n박스 안\n::::''';
+      const data = '''::::checked[라벨]\n박스 안\n::::''';
 
       /// 문장 쪼개기
       final lines = LineSplitter.split(data).cast<Line>().toList();
@@ -213,7 +213,7 @@ void main() {
 
       expect(
         nodes.first,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having((e) => e.tag, '태그', 'boxedblock')
             .having(
               (e) => e.children,
@@ -255,7 +255,7 @@ void main() {
     ///       첫번째 노드의 텍스트는 '박스 속' 이다
     ///       블록의 두번째 노드는 엘리먼트 다
     test('박스 블록 속 박스 블록', () {
-      final data = '::::boxed[Point]\n박스 속\n:::boxed\n박스 속 박스\n:::\n::::';
+      const data = '::::boxed[Point]\n박스 속\n:::boxed\n박스 속 박스\n:::\n::::';
 
       final lines = LineSplitter.split(data).cast<Line>().toList();
       final nodes = BlockParser(lines, document).parseLines();
@@ -265,7 +265,7 @@ void main() {
 
       expect(
         outerBlock,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.children,
               '하위 노드 수',
@@ -300,7 +300,7 @@ void main() {
 
       expect(
         innerText,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',
@@ -317,7 +317,7 @@ void main() {
 
       expect(
         innerBlock,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.children,
               '하위 노드 수 ',
@@ -343,7 +343,7 @@ void main() {
 
       expect(
         innerTextInInnerBlock,
-        TypeMatcher<Element>()
+        const TypeMatcher<Element>()
             .having(
               (e) => e.tag,
               '태그',

--- a/test/block_syntax/fenced_tex_block_syntax_test.dart
+++ b/test/block_syntax/fenced_tex_block_syntax_test.dart
@@ -8,10 +8,11 @@ void main() {
     /// MD 다큐먼트 생성
     final document = Document(
       blockSyntaxes: [
-        FencedTexBlockSyntax(),
+        const FencedTexBlockSyntax(),
       ],
       encodeHtml: false,
     );
+    // ignore: prefer_const_declarations
     final data = r'''
 $$
 \displaystyle \int\_{a}^{b}f\left( x\right)dx=\left[ F\left( x\right)\right]\_{a}^{b}=F\left( b\right)-F\left( a\right)
@@ -29,7 +30,7 @@ $a$
 
     expect(
       nodes[0],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             r'$$ 블락 분석기에 걸러진 문자',
@@ -45,7 +46,7 @@ $a$
 
     expect(
       nodes[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             r'$$ 블락 분석기에 걸러지지 않은 문자',

--- a/test/inline_syntax/code_syntax_test.dart
+++ b/test/inline_syntax/code_syntax_test.dart
@@ -7,7 +7,7 @@ void main() {
   setUp(() {
     document = Document(
       blockSyntaxes: [
-        HeaderSyntax(),
+        const HeaderSyntax(),
       ],
       encodeHtml: false,
     );
@@ -20,7 +20,7 @@ void main() {
     ///       태그가 'code'인 노드는 1개 이다
     ///       태그가 'code'인 노드는 엘리먼트이며 텍스트는 '①' 이다
     test('일반적인 데이터 파싱', () {
-      final data = r'`①` $f(x)$ 의 값이 한없이 커지는 경우';
+      const data = r'`①` $f(x)$ 의 값이 한없이 커지는 경우';
 
       /// 파싱결과
       final result = document.parseInline(data);
@@ -35,7 +35,7 @@ void main() {
 
       expect(
         codeElements.first,
-        TypeMatcher<Element>().having(
+        const TypeMatcher<Element>().having(
           (e) => e.textContent,
           '텍스트',
           '①',
@@ -50,9 +50,9 @@ void main() {
     ///       태그가 'code'인 노드는 1개 이다
     ///       태그가 'code'인 노드는 엘리먼트이며 텍스트는 '●○○○' 이다
     test('난이도와 함께 주어진 데이터 파싱', () {
-      final data = '### **1.** `OXXX`';
+      const data = '### **1.** `OXXX`';
 
-      final lines = LineSplitter().convert(data).toList();
+      final lines = const LineSplitter().convert(data).toList();
 
       /// 파싱결과
       final nodes = document.parseLines(lines);
@@ -63,7 +63,7 @@ void main() {
 
       expect(
         topNode,
-        TypeMatcher<Element>().having(
+        const TypeMatcher<Element>().having(
           (e) => e.tag,
           '태그',
           'h3',
@@ -79,7 +79,7 @@ void main() {
 
       expect(
         codeElements?.first,
-        TypeMatcher<Element>().having(
+        const TypeMatcher<Element>().having(
           (e) => e.textContent,
           '텍스트',
           '●○○○',

--- a/test/inline_syntax/double_tex_syntax_test.dart
+++ b/test/inline_syntax/double_tex_syntax_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             r'$ 구문 분석기에 걸러진 문자',
@@ -34,7 +34,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         r'$ 구문 분석기에 걸러지지 않은 문자',
         equals(r'라서$f(a)$'),

--- a/test/inline_syntax/highlight_syntax_test.dart
+++ b/test/inline_syntax/highlight_syntax_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         '<mark></mark> 구문 분석기에 걸러지지 않은 문자',
         equals('Text'),
@@ -28,7 +28,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             '<mark></mark> 구문 분석기에 걸러진 문자',

--- a/test/inline_syntax/non_breaking_space_syntax_test.dart
+++ b/test/inline_syntax/non_breaking_space_syntax_test.dart
@@ -1,5 +1,4 @@
 import 'package:markdown/markdown.dart';
-import 'package:markdown/src/inline_syntaxes/non_breaking_space_syntax.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/inline_syntax/single_tex_syntax_test.dart
+++ b/test/inline_syntax/single_tex_syntax_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             r'$ 구문 분석기에 걸러진 문자',
@@ -34,7 +34,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         r'$ 구문 분석기에 걸러지지 않은 문자',
         equals('라서'),
@@ -43,7 +43,7 @@ void main() {
 
     expect(
       result[2],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             r'$ 구문 분석기에 걸러진 문자',

--- a/test/inline_syntax/strikethrough_syntax_test.dart
+++ b/test/inline_syntax/strikethrough_syntax_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         '~ 구문 분석기에 걸러지지 않은 문자',
         equals('Text'),
@@ -27,7 +27,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             '~ 구문 분석기에 걸러진 문자',

--- a/test/inline_syntax/strong_code_syntax_test.dart
+++ b/test/inline_syntax/strong_code_syntax_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         '**``** 구문 분석기에 걸러지지 않은 문자',
         equals('Text'),
@@ -27,7 +27,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             '**``** 구문 분석기에 걸러진 문자',

--- a/test/inline_syntax/sub_syntax_test.dart
+++ b/test/inline_syntax/sub_syntax_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         '<sub></sub> 구문 분석기에 걸러지지 않은 문자',
         equals('Text'),
@@ -27,7 +27,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             '<sub></sub> 구문 분석기에 걸러진 문자',

--- a/test/inline_syntax/sup_syntax_test.dart
+++ b/test/inline_syntax/sup_syntax_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         '<sup></sup> 구문 분석기에 걸러지지 않은 문자',
         equals('Text'),
@@ -27,7 +27,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             '<sup></sup> 구문 분석기에 걸러진 문자',

--- a/test/inline_syntax/underline_syntax_test.dart
+++ b/test/inline_syntax/underline_syntax_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     expect(
       result[0],
-      TypeMatcher<Text>().having(
+      const TypeMatcher<Text>().having(
         (e) => e.textContent,
         '<u></u> 구문 분석기에 걸러지지 않은 문자',
         equals('Text'),
@@ -27,7 +27,7 @@ void main() {
 
     expect(
       result[1],
-      TypeMatcher<Element>()
+      const TypeMatcher<Element>()
           .having(
             (e) => e.textContent,
             '<u></u> 구문 분석기에 걸러진 문자',


### PR DESCRIPTION
박스문법을 3개 이상 사용하는 경우 발생하는 버그

현재 최대 2개까지는 대응되는것으로 확인됨.
박스 문법이란 처음과 끝에 :::가 사용되는 문법인데, 복수로 사용될 경우 :를 하나씩 늘려 사용합니다. 그런데 앱에서는 박스 안의 박스 까지만 대응이 되어 아래와 같은 경우는 변환되지 않는 것으로 확인됩니다.

### 수정 코드 
정규식을 파싱하는 부분에서 3개까지만 :를 인식하게 되어있던것을 
3개 이상도 인식할 수 있게 했습니다. 

patterns.dart의 boxFencePattern 수정
